### PR TITLE
With meson 0.50 is an error give the full path to the installation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,8 +36,7 @@ libversion = '@0@.@1@.@2@'.format(soversion, current, revision)
 wing_prefix = get_option('prefix')
 wing_libdir = join_paths(wing_prefix, get_option('libdir'))
 wing_includedir = join_paths(wing_prefix, get_option('includedir'))
-wing_includedir_real = join_paths(wing_includedir,
-                                  wing_api_name,
+wing_includedir_real = join_paths(wing_api_name,
                                   meson.project_name())
 wing_datadir = join_paths(wing_prefix, get_option('datadir'))
 


### PR DESCRIPTION
I'm building the gvsbuild stack with the new meson version (to avoid the need for pylauncher) and without this change an error is generated on the include header install (ERROR: Subdir keyword must not be an absolute path.)